### PR TITLE
added the NFT collection page and added an app.tsx Route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Roadmap from './views/Roadmap';
 import Game from './views/Game';
 import Navbar from './components/Navbar/index';
 import Cover from './views/Cover';
+import NftCollection from './components/NFTCollection/index';
 import './App.css';
 
 function App() {
@@ -22,6 +23,7 @@ function App() {
                 <Route path='/nftroom' element={<NftRoom />} />
                 <Route path='/roadmap' element={<Roadmap />} />
                 <Route path='/game' element={<Game />} />
+                <Route path='/nftcollection/:collectionName' element={<NftCollection />} />
               </Routes>
             ) : (
               <Cover />

--- a/src/components/NFTCollection/index.tsx
+++ b/src/components/NFTCollection/index.tsx
@@ -1,0 +1,44 @@
+import { Link, useParams } from 'react-router-dom';
+import './main.css';
+
+interface NftMetaData {
+  name: string;
+  image: string;
+  tokenId: number;
+}
+
+export default function Component() {
+  const { collectionName } = useParams<{ collectionName: string }>();
+
+  // Dummy data for the collection
+  const collection: NftMetaData[] = [
+    { name: "Mystic Animals #0", image: "/placeholder.svg?height=200&width=200", tokenId: 0 },
+    { name: "Mystic Animals #1", image: "/placeholder.svg?height=200&width=200", tokenId: 1 },
+    { name: "Mystic Animals #2", image: "/placeholder.svg?height=200&width=200", tokenId: 2 },
+    { name: "Mystic Animals #3", image: "/placeholder.svg?height=200&width=200", tokenId: 3 },
+    { name: "Mystic Animals #4", image: "/placeholder.svg?height=200&width=200", tokenId: 4 },
+    { name: "Mystic Animals #5", image: "/placeholder.svg?height=200&width=200", tokenId: 5 },
+    { name: "Mystic Animals #6", image: "/placeholder.svg?height=200&width=200", tokenId: 6 },
+  ];
+
+  return (
+    <div className="nft-room">
+      <div className="container">
+        <div className="section-title">
+          <span>Collectibles</span>
+          <h2>Collection</h2>
+          <h2 className="collection-name">{collectionName}</h2>
+        </div>
+        <div className="separator"></div>
+        <div className="collection">
+          {collection.map(({ name, image, tokenId }) => (
+            <Link key={tokenId} to={`/nftroom/${collectionName}/${tokenId}`} className="nft-card">
+              <img src={image} alt={name} />
+              <p>{name}</p>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NFTCollection/index.tsx
+++ b/src/components/NFTCollection/index.tsx
@@ -1,41 +1,105 @@
 import { Link, useParams } from 'react-router-dom';
+import LuisImg from '../../assets/img/Luis.png';
+import Daniel from '../../assets/img/daniel.jpeg';
+import Marco from '../../assets/img/marco.jpeg';
+import Rol from '../../assets/img/rol.jpg';
 import './main.css';
 
 interface NftMetaData {
   name: string;
+  description: string;
   image: string;
   tokenId: number;
+  owner: string;
 }
 
 export default function Component() {
   const { collectionName } = useParams<{ collectionName: string }>();
 
   // Dummy data for the collection
-  const collection: NftMetaData[] = [
-    { name: "Mystic Animals #0", image: "/placeholder.svg?height=200&width=200", tokenId: 0 },
-    { name: "Mystic Animals #1", image: "/placeholder.svg?height=200&width=200", tokenId: 1 },
-    { name: "Mystic Animals #2", image: "/placeholder.svg?height=200&width=200", tokenId: 2 },
-    { name: "Mystic Animals #3", image: "/placeholder.svg?height=200&width=200", tokenId: 3 },
-    { name: "Mystic Animals #4", image: "/placeholder.svg?height=200&width=200", tokenId: 4 },
-    { name: "Mystic Animals #5", image: "/placeholder.svg?height=200&width=200", tokenId: 5 },
-    { name: "Mystic Animals #6", image: "/placeholder.svg?height=200&width=200", tokenId: 6 },
+  const animals: NftMetaData[] = [
+    {
+      name: "Mystic Animals #1",
+      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
+      image: LuisImg,
+      tokenId: 1,
+      owner: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+    },
+    {
+      name: "Mystic Animals #2",
+      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
+      image: Daniel,
+      tokenId: 2,
+      owner: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+    },
+    {
+      name: "Mystic Animals #3",
+      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
+      image: Rol,
+      tokenId: 3,
+      owner: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+    },
+    {
+      name: "Mystic Animals #4",
+      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
+      image: Marco,
+      tokenId: 4,
+      owner: "0x123d35Cc6634C0532925a3b844Bc454e4438f123"
+    },
+    {
+      name: "Mystic Animals #5",
+      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
+      image: Rol,
+      tokenId: 5,
+      owner: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+    },
+    {
+      name: "Mystic Animals #6",
+      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
+      image: Daniel,
+      tokenId: 6,
+      owner: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+    },
+    {
+      name: "Mystic Animals #7",
+      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
+      image: Marco,
+      tokenId: 7,
+      owner: "0x123d35Cc6634C0532925a3b844Bc454e4438f123"
+    },
+    {
+      name: "Mystic Animals #8",
+      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
+      image: LuisImg,
+      tokenId: 8,
+      owner: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+    },
+    {
+      name: "Mystic Animals #9",
+      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
+      image: Daniel,
+      tokenId: 9,
+      owner: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+    }
   ];
 
   return (
     <div className="nft-room">
       <div className="container">
-        <div className="section-title">
-          <span>Collectibles</span>
-          <h2>Collection</h2>
-          <h2 className="collection-name">{collectionName}</h2>
+        <div className="section-title text-center my-4">
+          <h1 className="display-5">Mystic Animals Collection</h1>
+          <span className="text-muted">A collection for the most fearless investors</span>
+          <h2 className="collection-name text-primary">{collectionName}</h2>
         </div>
         <div className="separator"></div>
-        <div className="collection">
-          {collection.map(({ name, image, tokenId }) => (
-            <Link key={tokenId} to={`/nftroom/${collectionName}/${tokenId}`} className="nft-card">
-              <img src={image} alt={name} />
-              <p>{name}</p>
-            </Link>
+        <div className="row">
+          {animals.map(({ name, image, tokenId }) => (
+            <div key={tokenId} className="col-6 col-md-4 col-lg-3 mb-4">
+              <Link to={`/nftroom/${collectionName}/${tokenId}`} className="nft-card d-block text-center p-1">
+                <img src={image} alt={name} className="img-fluid" />
+                <p className="mt-2">{name}</p>
+              </Link>
+            </div>
           ))}
         </div>
       </div>

--- a/src/components/NFTCollection/index.tsx
+++ b/src/components/NFTCollection/index.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import LuisImg from '../../assets/img/Luis.png';
 import Daniel from '../../assets/img/daniel.jpeg';
 import Marco from '../../assets/img/marco.jpeg';
@@ -7,102 +7,49 @@ import './main.css';
 
 interface NftMetaData {
   name: string;
-  description: string;
   image: string;
   tokenId: number;
-  owner: string;
 }
 
 export default function Component() {
-  const { collectionName } = useParams<{ collectionName: string }>();
 
-  // Dummy data for the collection
   const animals: NftMetaData[] = [
-    {
-      name: "Mystic Animals #1",
-      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
-      image: LuisImg,
-      tokenId: 1,
-      owner: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-    },
-    {
-      name: "Mystic Animals #2",
-      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
-      image: Daniel,
-      tokenId: 2,
-      owner: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
-    },
-    {
-      name: "Mystic Animals #3",
-      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
-      image: Rol,
-      tokenId: 3,
-      owner: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-    },
-    {
-      name: "Mystic Animals #4",
-      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
-      image: Marco,
-      tokenId: 4,
-      owner: "0x123d35Cc6634C0532925a3b844Bc454e4438f123"
-    },
-    {
-      name: "Mystic Animals #5",
-      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
-      image: Rol,
-      tokenId: 5,
-      owner: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-    },
-    {
-      name: "Mystic Animals #6",
-      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
-      image: Daniel,
-      tokenId: 6,
-      owner: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
-    },
-    {
-      name: "Mystic Animals #7",
-      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
-      image: Marco,
-      tokenId: 7,
-      owner: "0x123d35Cc6634C0532925a3b844Bc454e4438f123"
-    },
-    {
-      name: "Mystic Animals #8",
-      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
-      image: LuisImg,
-      tokenId: 8,
-      owner: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-    },
-    {
-      name: "Mystic Animals #9",
-      description: "Mystic Animals is a collection that is only owned by the most fearless investors",
-      image: Daniel,
-      tokenId: 9,
-      owner: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
-    }
+    { name: "Mystic Animals #1", image: LuisImg, tokenId: 1 },
+    { name: "Mystic Animals #2", image: Daniel, tokenId: 2 },
+    { name: "Mystic Animals #3", image: Rol, tokenId: 3 },
+    { name: "Mystic Animals #4", image: Marco, tokenId: 4 },
+    { name: "Mystic Animals #5", image: Rol, tokenId: 5 },
+    { name: "Mystic Animals #6", image: Daniel, tokenId: 6 },
+    { name: "Mystic Animals #7", image: Marco, tokenId: 7 },
+    { name: "Mystic Animals #8", image: LuisImg, tokenId: 8 },
+    { name: "Mystic Animals #9", image: Daniel, tokenId: 9 }
   ];
 
   return (
-    <div className="nft-room">
-      <div className="container">
-        <div className="section-title text-center my-4">
-          <h1 className="display-5">Mystic Animals Collection</h1>
-          <span className="text-muted">A collection for the most fearless investors</span>
-          <h2 className="collection-name text-primary">{collectionName}</h2>
-        </div>
-        <div className="separator"></div>
-        <div className="row">
-          {animals.map(({ name, image, tokenId }) => (
-            <div key={tokenId} className="col-6 col-md-4 col-lg-3 mb-4">
-              <Link to={`/nftroom/${collectionName}/${tokenId}`} className="nft-card d-block text-center p-1">
-                <img src={image} alt={name} className="img-fluid" />
-                <p className="mt-2">{name}</p>
-              </Link>
+    <>
+      {
+        <div className="nft-room">
+          <div className={"nft-owner"}>
+            <div className="section-title title-style-two text-center mb-60">
+              <span>Collectibles</span>
+              <h2>
+                Holder <span className="d-block">0xdAC...1ec7</span>
+              </h2>
             </div>
-          ))}
+            <div className="collection row">
+              {animals.map(({ name, image, tokenId }: NftMetaData) => {
+                return (
+                  <Link key={tokenId} to={`/nftroom/`} className="col-4 yellow">
+                    <div className="nft-card">
+                      <img src={image} alt="" />
+                      <p>{name}</p>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
-  );
-}
+      }
+    </>
+  );}

--- a/src/components/NFTCollection/main.css
+++ b/src/components/NFTCollection/main.css
@@ -1,35 +1,103 @@
-.nft-room .section-title {
-  padding-bottom: 1rem;
-  color: #343a40;
+body {
+  background-color: #000;
+  color: #fff;
+  font-family: Arial, sans-serif;
 }
 
-.nft-room .separator {
-  margin: 1rem 0;
-  border-bottom: 2px solid #dee2e6;
+.nft-room {
+  min-height: 100vh;
+  padding-bottom: 80px;
+}
+
+.logo {
+  height: 32px;
+}
+
+.brand-name {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #ffd700;
+}
+
+.btn-connect {
+  background-color: #8b0000;
+  color: #fff;
+  border: none;
+}
+
+.collectibles-title {
+  font-size: 1rem;
+  color: #808080;
+  text-transform: uppercase;
+}
+
+.holder-title {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.text-highlight {
+  color: #ffd700;
 }
 
 .nft-card {
   border-radius: 10px;
   overflow: hidden;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease;
   text-decoration: none;
   color: inherit;
 }
 
 .nft-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+  transform: scale(1.05);
 }
 
-.card-content img {
+.nft-card img {
   border-radius: 8px;
   width: 100%;
   height: auto;
 }
 
-.card-content p {
-  font-size: 1.1rem;
-  color: #333;
+.nft-card p {
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(10px);
+  padding: 1rem;
+}
+
+.nav-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: #fff;
+  font-size: 0.8rem;
+}
+
+.nav-icon {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin-bottom: 4px;
+}
+
+.mint-beast {
+  background-color: #00ff00;
+}
+
+.play-game, .nft {
+  background-color: #ffd700;
+}
+
+.roadmap {
+  background-color: #800080;
 }
 
 @media (min-width: 768px) {

--- a/src/components/NFTCollection/main.css
+++ b/src/components/NFTCollection/main.css
@@ -1,0 +1,85 @@
+.nft-room {
+    background-color: #1a1a2e;
+    color: white;
+    min-height: 100vh;
+    padding: 20px;
+  }
+  
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+  
+  .section-title {
+    text-align: center;
+    margin-bottom: 40px;
+  }
+  
+  .section-title span {
+    font-size: 18px;
+    color: #888;
+    display: block;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+  }
+  
+  .section-title h2 {
+    font-size: 36px;
+    color: white;
+    margin: 0;
+  }
+  
+  .section-title .collection-name {
+    color: #ffa500;
+    font-size: 32px;
+  }
+  
+  .separator {
+    width: 100%;
+    height: 1px;
+    background: linear-gradient(to right, transparent, #888, transparent);
+    margin-bottom: 40px;
+  }
+  
+  .collection {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+  
+  .nft-card {
+    background-color: transparent;
+    border-radius: 10px;
+    overflow: hidden;
+    text-decoration: none;
+    color: #ffa500;
+    transition: transform 0.3s ease;
+  }
+  
+  .nft-card:hover {
+    transform: scale(1.05);
+  }
+  
+  .nft-card img {
+    width: 100%;
+    border-radius: 10px;
+    margin-bottom: 10px;
+  }
+  
+  .nft-card p {
+    text-align: center;
+    font-size: 14px;
+    margin: 0;
+  }
+  
+  @media (max-width: 768px) {
+    .collection {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+  
+  @media (max-width: 480px) {
+    .collection {
+      grid-template-columns: 1fr;
+    }
+  }

--- a/src/components/NFTCollection/main.css
+++ b/src/components/NFTCollection/main.css
@@ -1,85 +1,39 @@
-.nft-room {
-    background-color: #1a1a2e;
-    color: white;
-    min-height: 100vh;
-    padding: 20px;
-  }
-  
-  .container {
-    max-width: 1200px;
-    margin: 0 auto;
-  }
-  
-  .section-title {
-    text-align: center;
-    margin-bottom: 40px;
-  }
-  
-  .section-title span {
-    font-size: 18px;
-    color: #888;
-    display: block;
-    margin-bottom: 10px;
-    text-transform: uppercase;
-  }
-  
-  .section-title h2 {
-    font-size: 36px;
-    color: white;
-    margin: 0;
-  }
-  
-  .section-title .collection-name {
-    color: #ffa500;
-    font-size: 32px;
-  }
-  
-  .separator {
-    width: 100%;
-    height: 1px;
-    background: linear-gradient(to right, transparent, #888, transparent);
-    margin-bottom: 40px;
-  }
-  
-  .collection {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 20px;
-  }
-  
+.nft-room .section-title {
+  padding-bottom: 1rem;
+  color: #343a40;
+}
+
+.nft-room .separator {
+  margin: 1rem 0;
+  border-bottom: 2px solid #dee2e6;
+}
+
+.nft-card {
+  border-radius: 10px;
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  text-decoration: none;
+  color: inherit;
+}
+
+.nft-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.card-content img {
+  border-radius: 8px;
+  width: 100%;
+  height: auto;
+}
+
+.card-content p {
+  font-size: 1.1rem;
+  color: #333;
+}
+
+@media (min-width: 768px) {
   .nft-card {
-    background-color: transparent;
-    border-radius: 10px;
-    overflow: hidden;
-    text-decoration: none;
-    color: #ffa500;
-    transition: transform 0.3s ease;
+    padding: 1.2rem;
   }
-  
-  .nft-card:hover {
-    transform: scale(1.05);
-  }
-  
-  .nft-card img {
-    width: 100%;
-    border-radius: 10px;
-    margin-bottom: 10px;
-  }
-  
-  .nft-card p {
-    text-align: center;
-    font-size: 14px;
-    margin: 0;
-  }
-  
-  @media (max-width: 768px) {
-    .collection {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-  
-  @media (max-width: 480px) {
-    .collection {
-      grid-template-columns: 1fr;
-    }
-  }
+}

--- a/src/components/NFTCollection/main.css
+++ b/src/components/NFTCollection/main.css
@@ -59,7 +59,7 @@ body {
 }
 
 .nft-card p {
-  font-size: 0.9rem;
+  font-size: 0.5rem;
   margin-top: 0.5rem;
 }
 


### PR DESCRIPTION
Fixes #6

**Title:** Add NftCollection Component with Static Data and Routing

---

### Description
This PR adds the `NftCollection` component, which displays all NFTs within a specified collection. The component is currently using static dummy data and includes a responsive grid layout, styled according to the existing website theme. Additionally, a new route for accessing each NFT collection has been added.

### Changes Implemented
- **New `NftCollection` Component**
  - Displays a grid layout of NFTs within a collection based on the `collectionName` parameter.
  - Uses static dummy data to simulate NFT metadata, including:
    - `name`
    - `description`
    - `image`
    - `token id`
   
- **Routing**
  - Added a new route in the main app file to render the `NftCollection` component:
    ```jsx
    <Route path="/nftcollection/:collectionName" element={<NftCollection />} />
    ```

- **Responsive Grid Layout**
  - Each NFT is displayed as a clickable card that links to the individual NFT page.
  - The layout includes a header section with the collection name and a grid for the NFT cards.

### Screenshots

![image](https://github.com/user-attachments/assets/59ad1d14-f2d6-4dd9-b9f6-04413e1d3588)

### How to Test
1. Navigate to `/nftcollection/{collectionName}` with any collection name in the URL.
2. Verify that the dummy data appears as expected in a grid format.
3. Click on each NFT card to check if the link routes correctly to the intended NFT detail page (with URL parameter `tokenId`).

Let me know if there are any specific updates or modifications required!